### PR TITLE
feat(bullet-hell/player): add co-op player attacks

### DIFF
--- a/Scenes/Levels/Minigames/BulletHell.tscn
+++ b/Scenes/Levels/Minigames/BulletHell.tscn
@@ -214,21 +214,27 @@ shape = SubResource("RectangleShape2D_vy5ie")
 [node name="Enemy" parent="." groups=["Enemy"] instance=ExtResource("2_vy5ie")]
 position = Vector2(548, 300)
 
-[node name="Player1" parent="." groups=["Player"] instance=ExtResource("5_4tn5h")]
+[node name="Player1" parent="." node_paths=PackedStringArray("other") groups=["Player"] instance=ExtResource("5_4tn5h")]
 position = Vector2(400, 500)
 left = &"left1"
 right = &"right1"
 up = &"up1"
 down = &"down1"
 jump = &"z"
+spike = &"x"
+wave = &"c"
+other = NodePath("../Player2")
 
-[node name="Player2" parent="." groups=["Player"] instance=ExtResource("5_4tn5h")]
+[node name="Player2" parent="." node_paths=PackedStringArray("other") groups=["Player"] instance=ExtResource("5_4tn5h")]
 position = Vector2(700, 500)
 left = &"left2"
 right = &"right2"
 up = &"up2"
 down = &"down2"
-jump = &"x"
+jump = &"slash"
+spike = &"."
+wave = &","
+other = NodePath("../Player1")
 
 [connection signal="button_down" from="GameUI/GameOver/Return" to="." method="_on_return_button_down"]
 [connection signal="button_down" from="GameUI/GameOver/Retry" to="." method="_on_retry_button_down"]

--- a/Scenes/Objects/BulletHell/player_shockwave.tscn
+++ b/Scenes/Objects/BulletHell/player_shockwave.tscn
@@ -1,0 +1,22 @@
+[gd_scene load_steps=4 format=3 uid="uid://2rex3a871vrv"]
+
+[ext_resource type="Script" uid="uid://bm2ibseonxs4c" path="res://Scripts/Objects/BulletHell/PlayerShockwave.gd" id="1_dwkr7"]
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_ljq4w"]
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_dwkr7"]
+radius = 20.0
+
+[node name="PlayerShockwave" type="Node2D"]
+script = ExtResource("1_dwkr7")
+width = 20.0
+
+[node name="Line2D" type="Line2D" parent="."]
+
+[node name="Area2D" type="Area2D" parent="."]
+
+[node name="CollisionInner2D" type="CollisionShape2D" parent="Area2D"]
+shape = SubResource("CircleShape2D_ljq4w")
+
+[node name="CollisionOuter2D" type="CollisionShape2D" parent="Area2D"]
+shape = SubResource("CircleShape2D_dwkr7")

--- a/Scenes/Objects/BulletHell/player_spike.tscn
+++ b/Scenes/Objects/BulletHell/player_spike.tscn
@@ -1,0 +1,14 @@
+[gd_scene load_steps=2 format=3 uid="uid://bgx8ixq6fdp76"]
+
+[ext_resource type="Script" uid="uid://bex3ytl4spxq4" path="res://Scripts/Objects/BulletHell/PlayerSpike.gd" id="1_nlugw"]
+
+[node name="PlayerSpike" type="Node2D"]
+script = ExtResource("1_nlugw")
+
+[node name="Line2D" type="Line2D" parent="."]
+points = PackedVector2Array(0, 0, 0, 0)
+width = 5.0
+
+[node name="Area2D" type="Area2D" parent="."]
+
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="Area2D"]

--- a/Scripts/Objects/BulletHell/PlayerShockwave.gd
+++ b/Scripts/Objects/BulletHell/PlayerShockwave.gd
@@ -1,0 +1,89 @@
+extends Node2D
+
+#region Class Preloads
+const Player = preload("res://Scripts/Objects/BulletHell/Player.gd")
+const Enemy = preload("res://Scripts/Objects/BulletHell/Enemy.gd")
+#endregion
+
+@export_group("Properties")
+@export_custom(PROPERTY_HINT_NONE, "suffix:px") var start_radius: float = 100
+@export_custom(PROPERTY_HINT_NONE, "suffix:px") var max_radius: float = 1000
+@export var spread_duration_sec: float = 1.0
+@export_custom(PROPERTY_HINT_NONE, "suffix:px") var width: float = 5
+
+var player: Player
+
+var time_elapsed_sec: float = 0.0
+var radius: float
+var inner_radius: float:
+	get: return max(0.0, radius - thickness)
+
+var thickness: float:
+	get: return $Line2D.width
+	set(width): $Line2D.width = width
+
+var centre: Vector2:
+	get: return self.position
+	set(new): self.position = new
+
+var area: Area2D:
+	get: return $Area2D
+
+var overlapping_bodies: Array[Node2D] = []
+
+func _update_circle_shape_radius(collision: CollisionShape2D, radius: float):
+	var circle = collision.shape as CircleShape2D
+	if circle != null:
+		circle.radius = radius
+
+func _update_circle():
+	# calculate new radius
+	var t = min(time_elapsed_sec / spread_duration_sec, 1.0)
+	radius = lerp(start_radius, max_radius, t)
+	
+	# update collision body shape
+	_update_circle_shape_radius($Area2D/CollisionOuter2D, radius)
+	_update_circle_shape_radius($Area2D/CollisionInner2D, inner_radius)
+
+	# calculate circle outline
+	var num_sides = 128
+	var points = PackedVector2Array()
+	var angle_delta = TAU / float(num_sides)
+	for i in range(num_sides + 1):
+		var angle = i * angle_delta
+		var x = cos(angle) * radius
+		var y = sin(angle) * radius
+		points.append(Vector2(x, y))
+	$Line2D.points = points
+
+func _is_body_in_outline(body: Node2D):
+	var dist = position.distance_to(body.position)
+	return dist > inner_radius and dist <= radius
+
+func _destroy():
+	if player != null:
+		player.shockwave = null
+	queue_free()
+
+func _ready():
+	thickness = width
+	radius = start_radius
+	if player != null:
+		centre = player.position
+	area.body_entered.connect(func(body): overlapping_bodies.append(body))
+	area.body_exited.connect(func(body): overlapping_bodies.erase(body))
+
+func _physics_process(delta):
+	if time_elapsed_sec >= spread_duration_sec:
+		_destroy()
+
+	time_elapsed_sec += delta
+	_update_circle()
+	for body in area.get_overlapping_bodies():
+		if not _is_body_in_outline(body):
+			continue
+		if body is Enemy:
+			# we may want a generic take damage if not everything is bullet
+			body.bulletDamaged()
+		if body is Player:
+			body.take_damage()

--- a/Scripts/Objects/BulletHell/PlayerShockwave.gd.uid
+++ b/Scripts/Objects/BulletHell/PlayerShockwave.gd.uid
@@ -1,0 +1,1 @@
+uid://bm2ibseonxs4c

--- a/Scripts/Objects/BulletHell/PlayerSpike.gd
+++ b/Scripts/Objects/BulletHell/PlayerSpike.gd
@@ -1,0 +1,63 @@
+extends Node2D
+
+#region Class Preloads
+const Player = preload("res://Scripts/Objects/BulletHell/Player.gd")
+const Enemy = preload("res://Scripts/Objects/BulletHell/Enemy.gd")
+#endregion
+
+@export_group("Properties")
+@export var active_time_sec: float = 2
+@export_custom(PROPERTY_HINT_NONE, "suffix:px") var width: float = 10
+
+var player: Player
+var tracker: Player.SharedState
+
+var thickness: float:
+	get: return $Line2D.width
+	set(width): $Line2D.width = width
+
+var start: Vector2:
+	get: return $Line2D.points[0]
+	set(start): $Line2D.points[0] = start
+
+var end: Vector2:
+	get: return $Line2D.points[1]
+	set(end): $Line2D.points[1] = end
+
+func _update_polygon():
+	# update line points
+	start = player.position
+	end = player.other.position
+
+	# calculate collision body
+	var p1 = start
+	var p2 = end
+	var dir = (p2 - p1).normalized()
+	var normal = Vector2(-dir.y, dir.x)
+	var width = thickness / 2
+	$Area2D/CollisionPolygon2D.polygon = [
+		p1 + normal * width,
+		p2 + normal * width,
+		p1 - normal * width,
+		p1 - normal * width,
+	];
+
+func _destroy() -> void:
+	if tracker != null:
+		tracker.spike = null
+	queue_free()
+
+func _ready() -> void:
+	thickness = width;
+	var t = get_tree().create_timer(active_time_sec)
+	t.timeout.connect(_destroy)
+
+func _physics_process(delta: float) -> void:
+	if player == null or player.other == null:
+		_destroy()
+
+	_update_polygon()
+	for body in $Area2D.get_overlapping_bodies():
+		if body is Enemy:
+			# we may want a generic take damage if not everything is bullet
+			body.bulletDamaged()

--- a/Scripts/Objects/BulletHell/PlayerSpike.gd.uid
+++ b/Scripts/Objects/BulletHell/PlayerSpike.gd.uid
@@ -1,0 +1,1 @@
+uid://bex3ytl4spxq4

--- a/Scripts/Objects/BulletHell/player.gd
+++ b/Scripts/Objects/BulletHell/player.gd
@@ -1,71 +1,150 @@
 extends CharacterBody2D
 
+#region Class Preloads
+const Player = preload("res://Scripts/Objects/BulletHell/Player.gd")
+const PlayerSpike = preload("res://Scripts/Objects/BulletHell/PlayerSpike.gd")
+const PlayerShockwave = preload("res://Scripts/Objects/BulletHell/PlayerShockwave.gd")
+const GameManager = preload("res://Scripts/Objects/BulletHell/GameManager.gd")
+
+const PLAYER_SPIKE_SCENE = preload("res://Scenes/Objects/BulletHell/player_spike.tscn")
+const PLAYER_SHOCKWAVE_SCENE = preload("res://Scenes/Objects/BulletHell/player_shockwave.tscn")
+#endregion
+
 enum PlayerState { GROUNDED, FALLING }
+const PlayerName = {
+	ONE = "Player1",
+	TWO = "Player2",
+}
 
 @export_group("Input Map")
-@export_subgroup("Movement")
 @export var left: StringName
 @export var right: StringName
 @export var up: StringName
 @export var down: StringName
-@export_subgroup("Action")
 @export var jump: StringName
+@export var spike: StringName
+@export var wave: StringName
 
-@onready var game_manager = get_node("/root/BulletHell")
+@export_group("References")
+@export var other: Player
+
+@onready var game_manager: GameManager = get_node("/root/BulletHell")
 
 var healthQuarts: float = 12.0
 var maxHealthQuarters: int = 12
 var canTakeDamage := true
 var damageCooldown := 0.5   # invulnerability timing in seconds
+var shockwave: PlayerShockwave = null
 signal health_changed(player: String, health: float)
 signal game_end
 
-const ORIGINAL_SCALE = Vector2(1, 1)
-const JUMP_SCALE = Vector2(1.5, 1.5)
+#region Shared Internals
+var shared = SharedState.get_instance()
+class SharedState extends RefCounted:
+	static var _instance: SharedState
+	var spike: PlayerSpike
+	
+	func _init():
+		if _instance != null:
+			printerr("attempted creation of second SharedState instance")
+			return
+		_instance = self
+		spike = null
 
+	func create_spike(creator: Player) -> PlayerSpike:
+		if spike != null:
+			return null
+
+		spike = PLAYER_SPIKE_SCENE.instantiate()
+		spike.player = creator
+		spike.tracker = self
+		return spike
+
+	static func get_instance() -> SharedState:
+		if _instance == null:
+			_instance = SharedState.new()
+		return _instance
+#endregion
+
+#region Sprite Internals
+var _sprite_original_scale: float
+var _sprite_scale: float:
+	get:
+		return $Sprite2D.scale.x / _sprite_original_scale
+	set(new_scale):
+		$Sprite2D.z_index = new_scale * 100
+		$Sprite2D.scale.x = _sprite_original_scale * new_scale
+		$Sprite2D.scale.y = _sprite_original_scale * new_scale
+
+func _sprite_init_scale():
+	_sprite_original_scale = $Sprite2D.scale.x
+
+func _sprite_update_state(state: PlayerState):
+	_sprite_scale = {
+		PlayerState.GROUNDED: 1.0,
+		PlayerState.FALLING: 1.5,
+	}[state]
+
+func _sprite_process_delta(delta: float):
+	if state == PlayerState.FALLING:
+		_sprite_scale -= delta
+		if _sprite_scale <= 1.0:
+			update_state(PlayerState.GROUNDED)
+#endregion
+
+#region State Internals
+var running: bool:
+	get: return not game_manager.getState(); # getState returns isEnded
 var state: PlayerState = PlayerState.GROUNDED
 
 func update_state(new_state: PlayerState):
 	state = new_state
-	match state:
-		PlayerState.GROUNDED:
-			$CollisionShape2D.disabled = false
-			scale = ORIGINAL_SCALE
-		PlayerState.FALLING:
-			$CollisionShape2D.disabled = true
-			scale = JUMP_SCALE
+	_sprite_update_state(new_state)
+#endregion
 
-func process_input():
+func _ready():
+	_sprite_init_scale()
+
+func _process_input():
 	# movement
 	var input_direction = Input.get_vector(left, right, up, down).normalized()
 	velocity = input_direction * 400
-	
+
 	# use name as the indicator for current player
-	if name == "Player1":
+	if name == PlayerName.ONE:
 		game_manager.setPlayer1Position(position)
-	elif name == "Player2":
+	elif name == PlayerName.TWO:
 		game_manager.setPlayer2Position(position)
-	
+
 	# jump
-	if (state == PlayerState.GROUNDED and Input.is_action_just_pressed(jump)):
+	if Input.is_action_just_pressed(jump) and state == PlayerState.GROUNDED:
 		update_state(PlayerState.FALLING)
 
+	# spike
+	if Input.is_action_just_pressed(spike) and other != null:
+		var spike = shared.create_spike(self)
+		if spike:
+			game_manager.add_child(spike)
+
+	# shockwave
+	if Input.is_action_just_pressed(wave) and shockwave == null:
+		shockwave = PLAYER_SHOCKWAVE_SCENE.instantiate()
+		shockwave.player = self
+		game_manager.add_child(shockwave)
+
 func _process(delta):
-	if not game_manager.getState():
-		process_input()
+	if not running:
+		return
+
+	_process_input()
 
 func _physics_process(delta):
-	if game_manager.getState():
+	if not running:
 		return
-	
+
 	move_and_slide()
-	if (state == PlayerState.FALLING):
-		scale.x -= delta
-		scale.y = scale.x
-		if (scale <= ORIGINAL_SCALE):
-			update_state(PlayerState.GROUNDED)
-		$Sprite2D.z_index = scale.x * 100
-	
+	_sprite_process_delta(delta)
+
 	# check for damage events
 	for i in get_slide_collision_count():
 		var collision = get_slide_collision(i)
@@ -79,14 +158,14 @@ func take_damage():
 	if not canTakeDamage:
 		return
 	canTakeDamage = false
-	
+
 	healthQuarts -= 1.0
 	emit_signal("health_changed", healthQuarts) # connected in game manager to heartsUI
 	print("Player hit! Health now:", healthQuarts)
-	
+
 	if healthQuarts == 0.0:
 		emit_signal("game_end")
-	
+
 	# start cooldown timer
 	var t = get_tree().create_timer(damageCooldown)
 	t.timeout.connect(func(): canTakeDamage = true)


### PR DESCRIPTION
### Features
- two new co-op attacks (sort-of, hopefully)
  - `"spike"-strip`: line between two players, will damage enemy if enter.  
*co-op*: the players have to stay apart from each other, otherwise the attack is useless
  - `shock-"wave"`: expanding circle outline from player that triggers it, hurts enemy and players.  
*co-op*: the players should stay together (within starting radius) to use, otherwise inflict damage on other

### Fixes
- Player sprite scale is now only done on Sprite2D, no more jumping over the boundary wall!
- remap Player1 and Player2 keybinds to be sensible (i.e., Player2 on RHS, but jump key was on LHS)

### Technical
- Player can now refer to the `other` Player.
- Player has `SharedState` singleton which serves as the "pairing" controller/object

### Notes
- may need to make `Enemy.takeDamage` instead of using `Enemy.bulletDamaged` if there are differing behaviors between bullet damage and co-op player attack damage